### PR TITLE
feat: add runtime components for Talend operators

### DIFF
--- a/talend2python_framework/talend2python/mapping/component_map.yaml
+++ b/talend2python_framework/talend2python/mapping/component_map.yaml
@@ -29,3 +29,60 @@ tFileOutputDelimited:
         path_key: "file_path"
         header_key: "header"
         sep_key: "separator"
+
+# Database components
+TMysqlConnection:
+      action: mysql_connect
+      params:
+        host_key: "host"
+        port_key: "port"
+        user_key: "user"
+        password_key: "password"
+        database_key: "database"
+TMysqlInput:
+      action: mysql_read
+      params:
+        query_key: "query"
+TMysqlOutput:
+      action: mysql_write
+      params:
+        table_key: "table"
+        mode_key: "if_exists"
+# File components
+TFileInputExcel:
+      action: read_excel
+      params:
+        path_key: "file_path"
+        sheet_key: "sheet"
+        header_key: "header"
+TFileList:
+      action: list_files
+      params:
+        dir_key: "directory"
+        pattern_key: "pattern"
+TFileArchive:
+      action: archive
+      params:
+        files_key: "files"
+        archive_path_key: "archive_path"
+        format_key: "format"
+TRowGenerator:
+      action: generate_rows
+      params:
+        schema_key: "schema"
+        num_rows_key: "num_rows"
+TMsgBox:
+      action: msg_box
+      params:
+        message_key: "message"
+# Flow control components
+TPreJob:
+      action: pre_job
+TJava:
+      action: python_exec
+      params:
+        code_key: "code"
+TRunJob:
+      action: run_job
+      params:
+        job_key: "job"

--- a/talend2python_framework/talend2python/runtime/__init__.py
+++ b/talend2python_framework/talend2python/runtime/__init__.py
@@ -1,0 +1,37 @@
+"""Runtime helpers for generated Talend pipelines."""
+
+from .components import (
+    TMysqlConnection,
+    TMysqlInput,
+    TMysqlOutput,
+    TFileInputDelimited,
+    TFileInputExcel,
+    TFileList,
+    TFileArchive,
+    TRowGenerator,
+    TMsgBox,
+    TLogRow,
+    TPreJob,
+    TMap,
+    TJoin,
+    TJava,
+    TRunJob,
+)
+
+__all__ = [
+    "TMysqlConnection",
+    "TMysqlInput",
+    "TMysqlOutput",
+    "TFileInputDelimited",
+    "TFileInputExcel",
+    "TFileList",
+    "TFileArchive",
+    "TRowGenerator",
+    "TMsgBox",
+    "TLogRow",
+    "TPreJob",
+    "TMap",
+    "TJoin",
+    "TJava",
+    "TRunJob",
+]

--- a/talend2python_framework/talend2python/runtime/components.py
+++ b/talend2python_framework/talend2python/runtime/components.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import pandas as pd
+import zipfile
+import tarfile
+
+
+@dataclass
+class TMysqlConnection:
+    """Simple representation of a MySQL connection."""
+
+    host: str
+    user: str
+    password: str
+    database: str
+    port: int = 3306
+
+    def engine(self):
+        """Create a SQLAlchemy engine for the connection."""
+        from sqlalchemy import create_engine  # Imported lazily
+
+        url = f"mysql+pymysql://{self.user}:{self.password}@{self.host}:{self.port}/{self.database}"
+        return create_engine(url)
+
+
+@dataclass
+class TMysqlInput:
+    """Run a query against a MySQL database and return a DataFrame."""
+
+    connection: TMysqlConnection
+    query: str
+
+    def read(self) -> pd.DataFrame:
+        engine = self.connection.engine()
+        return pd.read_sql_query(self.query, con=engine)
+
+
+@dataclass
+class TMysqlOutput:
+    """Write a DataFrame to a MySQL table."""
+
+    connection: TMysqlConnection
+    table: str
+    if_exists: str = "append"
+
+    def write(self, df: pd.DataFrame) -> None:
+        engine = self.connection.engine()
+        df.to_sql(self.table, con=engine, if_exists=self.if_exists, index=False)
+
+
+@dataclass
+class TFileInputDelimited:
+    """Read a delimited text file into a DataFrame."""
+
+    path: str
+    separator: str = ","
+    header: bool = True
+
+    def read(self) -> pd.DataFrame:
+        header_row = 0 if self.header else None
+        return pd.read_csv(self.path, sep=self.separator, header=header_row)
+
+
+@dataclass
+class TFileInputExcel:
+    """Read an Excel file into a DataFrame."""
+
+    path: str
+    sheet: str | int = 0
+    header: bool = True
+
+    def read(self) -> pd.DataFrame:
+        header_row = 0 if self.header else None
+        return pd.read_excel(self.path, sheet_name=self.sheet, header=header_row)
+
+
+@dataclass
+class TFileList:
+    """List files matching a pattern inside a directory."""
+
+    directory: str
+    pattern: str = "*"
+
+    def list_files(self) -> List[str]:
+        base = Path(self.directory)
+        return [str(p) for p in base.glob(self.pattern)]
+
+
+@dataclass
+class TFileArchive:
+    """Create an archive (zip or tar.gz) from a set of files."""
+
+    files: List[str]
+    archive_path: str
+    format: str = "zip"
+
+    def archive(self) -> None:
+        if self.format == "zip":
+            with zipfile.ZipFile(self.archive_path, "w", zipfile.ZIP_DEFLATED) as zf:
+                for f in self.files:
+                    zf.write(f, arcname=Path(f).name)
+        elif self.format in ("tar", "gztar", "tar.gz"):
+            mode = "w:gz" if "gz" in self.format else "w"
+            with tarfile.open(self.archive_path, mode) as tf:
+                for f in self.files:
+                    tf.add(f, arcname=Path(f).name)
+        else:
+            raise ValueError(f"Unsupported archive format: {self.format}")
+
+
+@dataclass
+class TRowGenerator:
+    """Generate a DataFrame of synthetic data."""
+
+    schema: Dict[str, Callable[[], Any]]
+    num_rows: int
+
+    def generate(self) -> pd.DataFrame:
+        data = {col: [fn() for _ in range(self.num_rows)] for col, fn in self.schema.items()}
+        return pd.DataFrame(data)
+
+
+@dataclass
+class TMsgBox:
+    """Display a simple message."""
+
+    message: str
+
+    def show(self) -> None:
+        print(self.message)
+
+
+@dataclass
+class TLogRow:
+    """Print the head of a DataFrame for debugging."""
+
+    n: int = 10
+
+    def log(self, df: pd.DataFrame) -> None:
+        print(df.head(self.n).to_string())
+
+
+@dataclass
+class TPreJob:
+    """Run a list of callables before the main job."""
+
+    tasks: List[Callable[[], Any]]
+
+    def run(self) -> None:
+        for task in self.tasks:
+            task()
+
+
+@dataclass
+class TMap:
+    """Select or compute new columns in a DataFrame."""
+
+    mapping: Dict[str, str]
+
+    def apply(self, df: pd.DataFrame) -> pd.DataFrame:
+        out = pd.DataFrame()
+        for col, expr in self.mapping.items():
+            if expr in {"__keep__", "__copy__"}:
+                out[col] = df[col]
+            else:
+                out[col] = df.eval(expr)
+        return out
+
+
+@dataclass
+class TJoin:
+    """Join two DataFrames."""
+
+    left_on: str
+    right_on: str
+    how: str = "inner"
+
+    def join(self, left_df: pd.DataFrame, right_df: pd.DataFrame) -> pd.DataFrame:
+        return left_df.merge(right_df, left_on=self.left_on, right_on=self.right_on, how=self.how)
+
+
+@dataclass
+class TJava:
+    """Execute a snippet of Python code (analogous to Talend's tJava)."""
+
+    code: str
+
+    def run(self, context: Optional[Dict[str, Any]] = None) -> None:
+        exec(self.code, {}, context if context is not None else {})
+
+
+@dataclass
+class TRunJob:
+    """Sequentially execute another job represented by a callable."""
+
+    job: Callable[..., Any]
+    args: List[Any] = field(default_factory=list)
+    kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    def run(self) -> Any:
+        return self.job(*self.args, **self.kwargs)
+


### PR DESCRIPTION
## Summary
- implement runtime classes for MySQL access, file utilities, row generation, logging and job control
- expand component mapping to include the new operators

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a74628354c8333b9d554b20b8301f9