### PR TITLE
Validate connectivity in Graph.topological_order

### DIFF
--- a/talend2python_framework/talend2python/ir/model.py
+++ b/talend2python_framework/talend2python/ir/model.py
@@ -56,4 +56,30 @@ class Graph:
                     queue.append(e.target)
         if len(order) != len(self.nodes):
             raise ValueError("Graph has cycles or is disconnected.")
+
+        # Ensure the graph is weakly connected.  The simple topological sort
+        # above will happily return an order even if the graph consists of
+        # multiple disconnected components because all nodes start with an
+        # indegree of zero.  This check traverses the graph ignoring edge
+        # direction and verifies that all nodes are reachable from the first
+        # node.  If not, the graph is considered disconnected.
+        if self.nodes:
+            from collections import deque
+
+            start = next(iter(self.nodes))
+            q: deque[str] = deque([start])
+            seen = set()
+            while q:
+                cur = q.popleft()
+                if cur in seen:
+                    continue
+                seen.add(cur)
+                neighbours = [e.target for e in self.edges if e.source == cur]
+                neighbours += [e.source for e in self.edges if e.target == cur]
+                for n in neighbours:
+                    if n not in seen:
+                        q.append(n)
+            if len(seen) != len(self.nodes):
+                raise ValueError("Graph has cycles or is disconnected.")
+
         return order

--- a/talend2python_framework/tests/test_graph.py
+++ b/talend2python_framework/tests/test_graph.py
@@ -1,0 +1,13 @@
+import pytest
+from talend2python.ir.model import Graph, Node, Edge
+
+def test_topological_order_disconnected():
+    g = Graph(
+        nodes={
+            'a': Node(id='a', type='t', name='A'),
+            'b': Node(id='b', type='t', name='B')
+        },
+        edges=[]
+    )
+    with pytest.raises(ValueError):
+        g.topological_order()


### PR DESCRIPTION
## Summary
- ensure Graph.topological_order raises ValueError on disconnected graphs by checking weak connectivity
- add regression test for disconnected graph scenarios

## Testing
- `PYTHONPATH=. pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a744af460483339cce601376612312