### PR TITLE
Enable XML string input for Talend jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python build/sample_job_pandas/main.py --input_csv talend2python_framework/data/
 ## CLI
 
 ```
-talend2py convert --input <path to .item> --out <dir> --engine [pyspark|pandas]
+talend2py convert (--input <path to .item> | --xml "<job xml>") --out <dir> --engine [pyspark|pandas]
 ```
 
 ## Project layout

--- a/talend2python/cli.py
+++ b/talend2python/cli.py
@@ -1,29 +1,41 @@
 """
 Command line interface for talend2python.
 
-This script exposes a ``convert`` subcommand that accepts a Talend .item file
-and generates equivalent Python or PySpark code.  It utilises the
-``parse_talend_item`` function to build an IR graph and then delegates to
-either the pandas or PySpark generator based on the ``--engine`` option.
+This script exposes a ``convert`` subcommand that accepts a Talend ``.item``
+file or raw XML content and generates equivalent Python or PySpark code. It
+utilises the ``parse_talend_item`` function to build an IR graph and then
+delegates to either the pandas or PySpark generator based on the ``--engine``
+option.
 """
 
 import argparse
 import pathlib
+
+from .generators import pandas_generator, pyspark_generator
 from .parsers.talend_xml_parser import parse_talend_item
-from .generators import pyspark_generator, pandas_generator
 
 
 def main():
-    p = argparse.ArgumentParser(prog="talend2py", description="Convert Talend .item to Python ETL code")
+    p = argparse.ArgumentParser(
+        prog="talend2py", description="Convert Talend .item to Python ETL code"
+        )
     sp = p.add_subparsers(dest="cmd", required=True)
     c = sp.add_parser("convert", help="Convert Talend job to Python code")
-    c.add_argument("--input", required=True, help="Path to Talend .item XML")
+    grp = c.add_mutually_exclusive_group(required=True)
+    grp.add_argument("--input", help="Path to Talend .item XML")
+    grp.add_argument("--xml", help="Raw Talend job XML content")
     c.add_argument("--out", required=True, help="Output directory for generated code")
-    c.add_argument("--engine", default="pyspark", choices=["pyspark", "pandas"], help="Execution engine")
+    c.add_argument(
+        "--engine",
+        default="pyspark",
+        choices=["pyspark", "pandas"],
+        help="Execution engine",
+    )
     args = p.parse_args()
 
     if args.cmd == "convert":
-        graph = parse_talend_item(args.input)
+        xml_source = args.input if args.input else args.xml
+        graph = parse_talend_item(xml_source)
         out_dir = pathlib.Path(args.out)
         out_dir.mkdir(parents=True, exist_ok=True)
         if args.engine == "pyspark":
@@ -31,3 +43,4 @@ def main():
         else:
             result = pandas_generator.generate(graph, out_dir)
         print(f"Generated {result['engine']} job at: {out_dir}")
+

--- a/talend2python/parsers/talend_xml_parser.py
+++ b/talend2python/parsers/talend_xml_parser.py
@@ -8,14 +8,27 @@ Components become ``Node`` instances and connections between them become
 strings in the ``config`` dictionary.
 """
 
+from pathlib import Path
+from typing import Union
+
 from lxml import etree
-from ..ir.model import Graph, Node, Edge
+
+from ..ir.model import Edge, Graph, Node
 
 
-def parse_talend_item(path: str) -> Graph:
-    """Parse a Talend .item file and return a Graph representation."""
-    tree = etree.parse(path)
-    root = tree.getroot()
+def parse_talend_item(source: Union[str, Path]) -> Graph:
+    """Parse a Talend job definition and return a ``Graph`` representation.
+
+    ``source`` may either be a filesystem path to a ``.item`` file or a raw
+    XML string containing the job definition.  When a path is supplied it must
+    point to an existing file; otherwise the value is treated as XML content.
+    """
+
+    if isinstance(source, (str, Path)) and Path(source).exists():
+        tree = etree.parse(str(source))
+        root = tree.getroot()
+    else:
+        root = etree.fromstring(str(source))
     g = Graph()
 
     # Create nodes

--- a/talend2python_framework/tests/test_parser.py
+++ b/talend2python_framework/tests/test_parser.py
@@ -9,3 +9,12 @@ def test_parse_basic_graph():
     assert len(g.edges) == 4
     order = g.topological_order()
     assert order[0].type == "tFileInputDelimited"
+
+
+def test_parse_from_xml_string():
+    xml = EXAMPLE_ITEM.read_text()
+    g = parse_talend_item(xml)
+    assert len(g.nodes) == 5
+    assert len(g.edges) == 4
+    order = g.topological_order()
+    assert order[0].type == "tFileInputDelimited"


### PR DESCRIPTION
## Summary
- Allow `parse_talend_item` to handle file paths or raw XML strings
- Extend CLI with `--xml` option to convert XML content directly
- Document new input mode and test parsing from XML strings

## Testing
- `pytest talend2python_framework/tests/test_parser.py talend2python_framework/tests/test_parser_unique_names.py -q`
- `pytest talend2python_framework/tests/test_generate_pyspark.py -q`
- `pytest talend2python_framework/tests/test_graph.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install sqlalchemy` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68a847e878e48333a664696f3385ed5d