### PR TITLE
Clarify graph cycle and connectivity errors

### DIFF
--- a/talend2python/ir/model.py
+++ b/talend2python/ir/model.py
@@ -59,7 +59,7 @@ class Graph:
                 if indeg[e.target] == 0:
                     queue.append(e.target)
         if len(order) != len(self.nodes):
-            raise ValueError("Graph has cycles or is disconnected.")
+            raise ValueError("Graph has cycles")
 
         # Ensure the graph is weakly connected.  The simple topological sort
         # above will happily return an order even if the graph consists of
@@ -84,6 +84,6 @@ class Graph:
                     if n not in seen:
                         q.append(n)
             if len(seen) != len(self.nodes):
-                raise ValueError("Graph has cycles or is disconnected.")
+                raise ValueError("Graph is disconnected")
 
         return order

--- a/talend2python_framework/tests/test_graph.py
+++ b/talend2python_framework/tests/test_graph.py
@@ -1,13 +1,26 @@
 import pytest
 from talend2python.ir.model import Graph, Node, Edge
 
+
 def test_topological_order_disconnected():
     g = Graph(
         nodes={
-            'a': Node(id='a', type='t', name='A'),
-            'b': Node(id='b', type='t', name='B')
+            "a": Node(id="a", type="t", name="A"),
+            "b": Node(id="b", type="t", name="B"),
         },
-        edges=[]
+        edges=[],
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Graph is disconnected"):
+        g.topological_order()
+
+
+def test_topological_order_cycle():
+    g = Graph(
+        nodes={
+            "a": Node(id="a", type="t", name="A"),
+            "b": Node(id="b", type="t", name="B"),
+        },
+        edges=[Edge(source="a", target="b"), Edge(source="b", target="a")],
+    )
+    with pytest.raises(ValueError, match="Graph has cycles"):
         g.topological_order()


### PR DESCRIPTION
## Summary
- Distinguish graph cycle errors from connectivity issues in `Graph.topological_order`
- Add explicit messages for disconnected graphs and cycles
- Extend tests to assert new error messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a85cc23eb48333894ece825c6e7a16