### PR TITLE
Allow code generation for disconnected graphs

### DIFF
--- a/talend2python/generators/pandas_generator.py
+++ b/talend2python/generators/pandas_generator.py
@@ -49,7 +49,7 @@ def generate(graph, out_dir):
     # which other dataframes should be available when rendering code for that
     # node.  Nodes with no inputs (e.g. file inputs) will have an empty list.
     steps = []
-    for node in graph.topological_order():
+    for node in graph.topological_order(require_connected=False):
         cfg = node.config or {}
         inputs = [edge.source for edge in graph.edges if edge.target == node.id]
         steps.append(

--- a/talend2python/generators/pyspark_generator.py
+++ b/talend2python/generators/pyspark_generator.py
@@ -43,7 +43,7 @@ def generate(graph, out_dir):
     # implementation in the pandas generator but returns a PySpark specific
     # template.
     steps = []
-    for node in graph.topological_order():
+    for node in graph.topological_order(require_connected=False):
         cfg = node.config or {}
         inputs = [edge.source for edge in graph.edges if edge.target == node.id]
         steps.append(

--- a/talend2python/ir/model.py
+++ b/talend2python/ir/model.py
@@ -33,13 +33,22 @@ class Graph:
     nodes: Dict[str, Node] = field(default_factory=dict)
     edges: List[Edge] = field(default_factory=list)
 
-    def topological_order(self) -> List[Node]:
+    def topological_order(self, require_connected: bool = True) -> List[Node]:
         """Return nodes in a topological order.
+
+        Parameters
+        ----------
+        require_connected:
+            When ``True`` (the default), the graph is required to be weakly
+            connected and a :class:`ValueError` is raised otherwise.  When set
+            to ``False`` the connectivity check is skipped and nodes from all
+            disconnected components are returned.
 
         This simple Kahn's algorithm implementation collects nodes with zero
         incoming edges, processes them and enqueues any neighbours whose
-        indegree drops to zero.  If there are cycles or disconnected nodes,
-        a ValueError is raised.
+        indegree drops to zero.  If there are cycles a ``ValueError`` is
+        raised.  When ``require_connected`` is ``True`` an additional
+        breadth‑first search ensures that all nodes are reachable.
         """
         indeg = {n: 0 for n in self.nodes}
         for e in self.edges:
@@ -61,13 +70,14 @@ class Graph:
         if len(order) != len(self.nodes):
             raise ValueError("Graph has cycles")
 
-        # Ensure the graph is weakly connected.  The simple topological sort
-        # above will happily return an order even if the graph consists of
-        # multiple disconnected components because all nodes start with an
-        # indegree of zero.  This check traverses the graph ignoring edge
-        # direction and verifies that all nodes are reachable from the first
-        # node.  If not, the graph is considered disconnected.
-        if self.nodes:
+        # Ensure the graph is weakly connected if requested.  The simple
+        # topological sort above will happily return an order even if the graph
+        # consists of multiple disconnected components because all nodes start
+        # with an indegree of zero.  When ``require_connected`` is ``True`` we
+        # traverse the graph ignoring edge direction and verify that all nodes
+        # are reachable from the first node.  If not, the graph is considered
+        # disconnected.
+        if require_connected and self.nodes:
             from collections import deque
 
             start = next(iter(self.nodes))

--- a/talend2python_framework/tests/test_generate_disconnected.py
+++ b/talend2python_framework/tests/test_generate_disconnected.py
@@ -1,0 +1,28 @@
+from talend2python.ir.model import Graph, Node
+from talend2python.generators.pandas_generator import generate as gen_pandas
+from talend2python.generators.pyspark_generator import generate as gen_pyspark
+
+
+def _build_disconnected_graph():
+    return Graph(
+        nodes={
+            "a": Node(id="a", type="t", name="A"),
+            "b": Node(id="b", type="t", name="B"),
+        },
+        edges=[],
+    )
+
+
+def test_generate_pandas_disconnected(tmp_path):
+    g = _build_disconnected_graph()
+    out = tmp_path / "pandas"
+    gen_pandas(g, out)
+    assert (out / "main.py").exists()
+
+
+def test_generate_pyspark_disconnected(tmp_path):
+    g = _build_disconnected_graph()
+    out = tmp_path / "pyspark"
+    gen_pyspark(g, out)
+    assert (out / "main.py").exists()
+

--- a/talend2python_framework/tests/test_graph.py
+++ b/talend2python_framework/tests/test_graph.py
@@ -14,6 +14,23 @@ def test_topological_order_disconnected():
         g.topological_order()
 
 
+def test_topological_order_disconnected_allowed():
+    g = Graph(
+        nodes={
+            "a1": Node(id="a1", type="t", name="A1"),
+            "a2": Node(id="a2", type="t", name="A2"),
+            "b1": Node(id="b1", type="t", name="B1"),
+            "b2": Node(id="b2", type="t", name="B2"),
+        },
+        edges=[Edge(source="a1", target="a2"), Edge(source="b1", target="b2")],
+    )
+    order = g.topological_order(require_connected=False)
+    ids = [n.id for n in order]
+    assert set(ids) == {"a1", "a2", "b1", "b2"}
+    assert ids.index("a1") < ids.index("a2")
+    assert ids.index("b1") < ids.index("b2")
+
+
 def test_topological_order_cycle():
     g = Graph(
         nodes={


### PR DESCRIPTION
## Summary
- make graph connectivity check optional via `require_connected`
- generate pandas and PySpark code across multiple components
- cover disconnected DAGs with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a85d930d0483339c9ca9956771e3f6