### PR TITLE
feat: expand component support for code conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@ A **workable framework** to convert Talend jobs (XML `.item`) into **Python ETL 
 ## Supported (MVP) Talend components
 
 - `tFileInputDelimited` (CSV read)
+- `tFileInputExcel` (Excel sheet read)
 - `tFilterRow` (row-level filter expressions)
 - `tMap` (select/rename/derive columns – basic expressions)
+- `tExtractDelimitedFields` (split a column into multiple columns)
+- `tAggregateRow` (group and aggregate data)
+- `tJoin` (join two flows)
 - `tLogRow` (debug sink)
 - `tFileOutputDelimited` (CSV write)
+- `tFileOutputExcel` (Excel write)
 
 You can add more components by extending `mapping/component_map.yaml` and generator templates.
 

--- a/talend2python/parsers/talend_xml_parser.py
+++ b/talend2python/parsers/talend_xml_parser.py
@@ -22,6 +22,14 @@ _KEY_MAP = {
     "FILENAME": "file_path",
     "FIELDSEPARATOR": "separator",
     "HEADER": "header",
+    # Additional parameters for extended component coverage
+    "SHEET": "sheet",
+    "GROUP_BY": "group_by",
+    "AGGREGATIONS": "aggregations",
+    "COLUMN": "column",
+    "NEW_COLUMNS": "new_columns",
+    "NUM_ROWS": "num_rows",
+    "SCHEMA": "schema",
 }
 
 

--- a/talend2python/templates/main_pandas.py.j2
+++ b/talend2python/templates/main_pandas.py.j2
@@ -19,11 +19,19 @@ def main():
     last_df = None
     {% for s in steps %}
     # Node: {{s.name}} ({{s.type}})
-    {% if s.type == "tFileInputDelimited" %}
+{% if s.type == "tFileInputDelimited" %}
     path = args.input_csv or "{{ s.config.get("file_path", "") }}"
     sep = "{{ s.config.get("separator", ",") }}"
     header = "{{ s.config.get("header", "true") }}".lower() == "true"
     df = pd.read_csv(path, sep=sep, header=0 if header else None)
+    df_map["{{s.id}}"] = df
+    last_df = df
+    {% elif s.type == "tFileInputExcel" %}
+    # Read an Excel sheet into a DataFrame
+    path = args.input_csv or "{{ s.config.get("file_path", "") }}"
+    sheet = "{{ s.config.get("sheet", 0) }}"
+    header = "{{ s.config.get("header", "true") }}".lower() == "true"
+    df = pd.read_excel(path, sheet_name=sheet, header=0 if header else None)
     df_map["{{s.id}}"] = df
     last_df = df
     {% elif s.type == "tFilterRow" %}
@@ -60,6 +68,22 @@ def main():
     df = left_df.merge(right_df, how=join_type, left_on=left_on, right_on=right_on)
     df_map["{{s.id}}"] = df
     last_df = df
+    {% elif s.type == "tExtractDelimitedFields" %}
+    # Split a delimited column into multiple new columns
+    column = "{{ s.config.get("column", "") }}"
+    sep = "{{ s.config.get("separator", ",") }}"
+    new_cols = json.loads('{{ s.config.get("new_columns", "[]") }}')
+    parts = last_df[column].str.split(sep, expand=True)
+    for i, col_name in enumerate(new_cols):
+        last_df[col_name] = parts[i]
+    df_map["{{s.id}}"] = last_df
+    {% elif s.type == "tAggregateRow" %}
+    # Aggregate rows based on group_by and aggregation mappings
+    group_by = json.loads('{{ s.config.get("group_by", "[]") }}')
+    aggregations = json.loads('{{ s.config.get("aggregations", "{}") }}')
+    df = last_df.groupby(group_by).agg(aggregations).reset_index()
+    df_map["{{s.id}}"] = df
+    last_df = df
     {% elif s.type == "tLogRow" %}
     # Print the first few rows of the current DataFrame.  to_string() is used
     # to avoid truncation of wide columns.
@@ -72,6 +96,13 @@ def main():
     sep = "{{ s.config.get("separator", ",") }}"
     header = "{{ s.config.get("header", "true") }}".lower() == "true"
     last_df.to_csv(out_path, index=False, sep=sep, header=header)
+    df_map["{{s.id}}"] = last_df
+    {% elif s.type == "tFileOutputExcel" %}
+    # Write the DataFrame to an Excel file
+    out_path = args.output_csv or "{{ s.config.get("file_path", "output.xlsx") }}"
+    sheet = "{{ s.config.get("sheet", "Sheet1") }}"
+    header = "{{ s.config.get("header", "true") }}".lower() == "true"
+    last_df.to_excel(out_path, index=False, sheet_name=sheet, header=header)
     df_map["{{s.id}}"] = last_df
     {% else %}
     # For components that don't perform any transformation (or are not yet

--- a/talend2python/templates/main_pyspark.py.j2
+++ b/talend2python/templates/main_pyspark.py.j2
@@ -1,7 +1,8 @@
 import argparse
 import json
+import pandas as pd
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import expr, col
+from pyspark.sql.functions import expr, col, split
 
 
 def parse_args():
@@ -20,11 +21,20 @@ def main():
     last_df = None
     {% for s in steps %}
     # Node: {{s.name}} ({{s.type}})
-    {% if s.type == "tFileInputDelimited" %}
+{% if s.type == "tFileInputDelimited" %}
     path = args.input_csv or "{{ s.config.get("file_path", "") }}"
     header = "{{ s.config.get("header", "true") }}".lower() == "true"
     sep = "{{ s.config.get("separator", ",") }}"
     df = spark.read.option("header", header).option("inferSchema", True).option("sep", sep).csv(path)
+    df_map["{{s.id}}"] = df
+    last_df = df
+    {% elif s.type == "tFileInputExcel" %}
+    # Load an Excel sheet using pandas then convert to Spark DataFrame
+    path = args.input_csv or "{{ s.config.get("file_path", "") }}"
+    sheet = "{{ s.config.get("sheet", 0) }}"
+    header = "{{ s.config.get("header", "true") }}".lower() == "true"
+    pdf = pd.read_excel(path, sheet_name=sheet, header=0 if header else None)
+    df = spark.createDataFrame(pdf)
     df_map["{{s.id}}"] = df
     last_df = df
     {% elif s.type == "tFilterRow" %}
@@ -56,6 +66,22 @@ def main():
     df = left_df.join(right_df, left_df[left_on] == right_df[right_on], how=join_type)
     df_map["{{s.id}}"] = df
     last_df = df
+    {% elif s.type == "tExtractDelimitedFields" %}
+    # Split a delimited string column into multiple columns using Spark split
+    column = "{{ s.config.get("column", "") }}"
+    sep = "{{ s.config.get("separator", ",") }}"
+    new_cols = json.loads('{{ s.config.get("new_columns", "[]") }}')
+    split_col = split(last_df[column], sep)
+    for idx, name in enumerate(new_cols):
+        last_df = last_df.withColumn(name, split_col.getItem(idx))
+    df_map["{{s.id}}"] = last_df
+    {% elif s.type == "tAggregateRow" %}
+    # Group and aggregate rows
+    group_by = json.loads('{{ s.config.get("group_by", "[]") }}')
+    aggregations = json.loads('{{ s.config.get("aggregations", "{}") }}')
+    df = last_df.groupBy(*[col(c) for c in group_by]).agg(aggregations)
+    df_map["{{s.id}}"] = df
+    last_df = df
     {% elif s.type == "tLogRow" %}
     last_df.show(10, truncate=False)
     df_map["{{s.id}}"] = last_df
@@ -64,6 +90,13 @@ def main():
     header = "{{ s.config.get("header", "true") }}".lower() == "true"
     sep = "{{ s.config.get("separator", ",") }}"
     last_df.coalesce(1).write.mode("overwrite").option("header", header).option("sep", sep).csv(out_path)
+    df_map["{{s.id}}"] = last_df
+    {% elif s.type == "tFileOutputExcel" %}
+    # Write to Excel via pandas
+    out_path = args.output_csv or "{{ s.config.get("file_path", "output.xlsx") }}"
+    sheet = "{{ s.config.get("sheet", "Sheet1") }}"
+    header = "{{ s.config.get("header", "true") }}".lower() == "true"
+    last_df.toPandas().to_excel(out_path, index=False, sheet_name=sheet, header=header)
     df_map["{{s.id}}"] = last_df
     {% else %}
     df_map["{{s.id}}"] = last_df

--- a/user_guide.md
+++ b/user_guide.md
@@ -78,6 +78,8 @@ Runtime components for execution
 | `tMap` | Select, rename, or derive columns via expressions | JSON `mapping` | Templates + runtime class |
 | `tJoin` | Join two DataFrames | `left_on`, `right_on`, `join_type` | Templates + runtime class |
 | `tLogRow` | Log the current DataFrame | n/a | Templates + runtime class |
+| `tAggregateRow` | Group and aggregate rows | `group_by`, `aggregations` | Templates + runtime class |
+| `tExtractDelimitedFields` | Split a column into new columns | `column`, `separator`, `new_columns` | Templates + runtime class |
 | `tFileOutputDelimited` | Write DataFrame to CSV | `file_path`, `separator`, `header` | Templates + runtime class |
 
 ### Database Components


### PR DESCRIPTION
## Summary
- extend parser key map for more Talend parameters
- handle Excel I/O, column splitting, and aggregations in generators
- document newly supported components

## Testing
- `pytest -q`
- `flake8` *(fails: command not found and install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fab5df34833394b3bdbfb6bfdb8a