### PR TITLE
feat: track component dependencies in IR graph

### DIFF
--- a/talend2python/generators/pandas_generator.py
+++ b/talend2python/generators/pandas_generator.py
@@ -43,22 +43,21 @@ def generate(graph, out_dir):
     )
     main_tpl = env.get_template("main_pandas.py.j2")
 
-    # Collect node information along with input dependencies.  The IR graph
-    # exposes a list of edges, where each edge has a ``source`` and ``target``
-    # attribute.  For each node we look up all incoming edges to determine
-    # which other dataframes should be available when rendering code for that
-    # node.  Nodes with no inputs (e.g. file inputs) will have an empty list.
+    # Collect node information along with input dependencies.  The call to
+    # ``topological_order`` populates each node's ``inputs`` list based on the
+    # graph's edges, so multi‑input components (e.g. tJoin) are handled
+    # automatically.  Nodes with no inputs (e.g. file inputs) will have an
+    # empty list.
     steps = []
     for node in graph.topological_order(require_connected=False):
         cfg = node.config or {}
-        inputs = [edge.source for edge in graph.edges if edge.target == node.id]
         steps.append(
             {
                 "id": node.id,
                 "type": node.type,
                 "name": node.name,
                 "config": cfg,
-                "inputs": inputs,
+                "inputs": list(node.inputs),
             }
         )
 

--- a/talend2python/generators/pyspark_generator.py
+++ b/talend2python/generators/pyspark_generator.py
@@ -39,20 +39,19 @@ def generate(graph, out_dir):
     )
     main_tpl = env.get_template("main_pyspark.py.j2")
 
-    # Build the steps list with input dependencies.  This mirrors the
-    # implementation in the pandas generator but returns a PySpark specific
-    # template.
+    # Build the steps list with input dependencies.  As in the pandas generator
+    # ``topological_order`` fills each node's ``inputs`` list, providing
+    # upstream node ids for multi‑input components.
     steps = []
     for node in graph.topological_order(require_connected=False):
         cfg = node.config or {}
-        inputs = [edge.source for edge in graph.edges if edge.target == node.id]
         steps.append(
             {
                 "id": node.id,
                 "type": node.type,
                 "name": node.name,
                 "config": cfg,
-                "inputs": inputs,
+                "inputs": list(node.inputs),
             }
         )
 

--- a/talend2python/mapping/component_map.yaml
+++ b/talend2python/mapping/component_map.yaml
@@ -21,6 +21,11 @@ tJoin:
         left_on_key: "left_on"
         right_on_key: "right_on"
         join_type_key: "join_type"
+TAggregateRow:
+      action: aggregate
+      params:
+        group_by_key: "group_by"
+        aggregations_key: "aggregations"
 tLogRow:
       action: log
 tFileOutputDelimited:

--- a/talend2python_framework/tests/test_graph.py
+++ b/talend2python_framework/tests/test_graph.py
@@ -41,3 +41,23 @@ def test_topological_order_cycle():
     )
     with pytest.raises(ValueError, match="Graph has cycles"):
         g.topological_order()
+
+
+def test_inputs_outputs_populated():
+    g = Graph(
+        nodes={
+            "s1": Node(id="s1", type="src", name="S1"),
+            "s2": Node(id="s2", type="src", name="S2"),
+            "j": Node(id="j", type="join", name="Join"),
+            "t": Node(id="t", type="tgt", name="T"),
+        },
+        edges=[
+            Edge(source="s1", target="j"),
+            Edge(source="s2", target="j"),
+            Edge(source="j", target="t"),
+        ],
+    )
+    g.topological_order()
+    assert g.nodes["j"].inputs == ["s1", "s2"]
+    assert g.nodes["s1"].outputs == ["j"]
+    assert g.nodes["t"].inputs == ["j"]


### PR DESCRIPTION
## Summary
- track upstream and downstream links for each Node in the intermediate representation
- use Node inputs in pandas and PySpark generators
- map TAggregateRow in component definitions and test multi-input graphs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac26b2b9248333a87eb4be3966889b