### PR TITLE
Add routine support and basic exception handling

### DIFF
--- a/talend2python/ir/model.py
+++ b/talend2python/ir/model.py
@@ -46,6 +46,7 @@ class Edge:
 class Graph:
     nodes: Dict[str, Node] = field(default_factory=dict)
     edges: List[Edge] = field(default_factory=list)
+    routines: List[str] = field(default_factory=list)
 
     def add_node(self, node: Node) -> None:
         """Add ``node`` to the graph."""

--- a/talend2python/parsers/talend_xml_parser.py
+++ b/talend2python/parsers/talend_xml_parser.py
@@ -148,4 +148,12 @@ def parse_talend_item(source: Union[str, Path]) -> Graph:
             )
         g.edges.append(Edge(source=src_id, target=tgt_id, connector=connector))
 
+    # Collect any declared routines so they can be made available during code
+    # generation.  Routines are stored by name only; the actual implementation
+    # is expected to be provided separately in Python modules.
+    for r in root.findall(".//routinesParameter"):
+        name = r.get("name")
+        if name:
+            g.routines.append(name)
+
     return g

--- a/talend2python/runtime/__init__.py
+++ b/talend2python/runtime/__init__.py
@@ -1,22 +1,31 @@
 """Runtime helpers for generated Talend pipelines."""
 
-from .components import (
-    TMysqlConnection,
-    TMysqlInput,
-    TMysqlOutput,
-    TFileInputDelimited,
-    TFileInputExcel,
-    TFileList,
-    TFileArchive,
-    TRowGenerator,
-    TMsgBox,
-    TLogRow,
-    TPreJob,
-    TMap,
-    TJoin,
-    TJava,
-    TRunJob,
-)
+try:
+    from .components import (
+        TMysqlConnection,
+        TMysqlInput,
+        TMysqlOutput,
+        TFileInputDelimited,
+        TFileInputExcel,
+        TFileList,
+        TFileArchive,
+        TRowGenerator,
+        TMsgBox,
+        TLogRow,
+        TPreJob,
+        TMap,
+        TJoin,
+        TJava,
+        TRunJob,
+    )
+except Exception:  # pragma: no cover - optional deps like pandas may be missing
+    TMysqlConnection = TMysqlInput = TMysqlOutput = None
+    TFileInputDelimited = TFileInputExcel = TFileList = None
+    TFileArchive = TRowGenerator = TMsgBox = None
+    TLogRow = TPreJob = TMap = TJoin = None
+    TJava = TRunJob = None
+from .utils import Talend2PyError, handle_component_error, safe_call
+from .routines import register, routine, registry
 
 __all__ = [
     "TMysqlConnection",
@@ -34,4 +43,10 @@ __all__ = [
     "TJoin",
     "TJava",
     "TRunJob",
+    "Talend2PyError",
+    "handle_component_error",
+    "safe_call",
+    "register",
+    "routine",
+    "registry",
 ]

--- a/talend2python/runtime/routines.py
+++ b/talend2python/runtime/routines.py
@@ -1,0 +1,39 @@
+"""Registry for user defined routine functions.
+
+Talend jobs often rely on custom Java routines.  The Python framework mirrors
+this by allowing users to register arbitrary callables which are then exposed to
+generated jobs.  Routines can be registered either via the :func:`routine`
+decorator or by calling :func:`register` directly.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+
+registry: Dict[str, Callable] = {}
+
+
+def register(name: str, func: Callable) -> None:
+    """Register ``func`` under ``name`` in the routine registry."""
+
+    registry[name] = func
+
+
+def routine(name: str) -> Callable[[Callable], Callable]:
+    """Decorator variant of :func:`register`.  Example::
+
+        @routine("MyRoutine")
+        def my_routine(x):
+            return x * 2
+    """
+
+    def deco(fn: Callable) -> Callable:
+        register(name, fn)
+        return fn
+
+    return deco
+
+
+__all__ = ["registry", "register", "routine"]
+

--- a/talend2python/runtime/utils.py
+++ b/talend2python/runtime/utils.py
@@ -1,1 +1,36 @@
-# Utils placeholder
+"""Runtime utility helpers and error handling primitives."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+class Talend2PyError(Exception):
+    """Base exception for all errors raised during job execution."""
+
+
+def handle_component_error(name: str, exc: Exception) -> None:
+    """Raise a :class:`Talend2PyError` with component context.
+
+    Parameters
+    ----------
+    name:
+        Name of the component that failed.
+    exc:
+        The original exception encountered while executing the component.
+    """
+
+    raise Talend2PyError(f"Component {name} failed") from exc
+
+
+def safe_call(func: Callable[..., Any], name: str, *args: Any, **kwargs: Any) -> Any:
+    """Execute ``func`` and wrap any exception using ``handle_component_error``."""
+
+    try:
+        return func(*args, **kwargs)
+    except Exception as e:  # pragma: no cover - thin wrapper
+        handle_component_error(name, e)
+
+
+__all__ = ["Talend2PyError", "handle_component_error", "safe_call"]
+

--- a/talend2python/templates/main_pandas.py.j2
+++ b/talend2python/templates/main_pandas.py.j2
@@ -1,6 +1,8 @@
 import argparse
 import json
 import pandas as pd
+from talend2python.runtime.utils import handle_component_error
+from talend2python.runtime.routines import registry
 
 
 def parse_args():
@@ -17,98 +19,104 @@ def main():
     args = parse_args()
     df_map = {}  # holds intermediate DataFrames keyed by node id
     last_df = None
+    # Expose registered routine functions in the global namespace so that
+    # custom code snippets can reference them directly.
+    globals().update(registry)
     {% for s in steps %}
     # Node: {{s.name}} ({{s.type}})
+    try:
 {% if s.type == "tFileInputDelimited" %}
-    path = args.input_csv or "{{ s.config.get("file_path", "") }}"
-    sep = "{{ s.config.get("separator", ",") }}"
-    header = "{{ s.config.get("header", "true") }}".lower() == "true"
-    df = pd.read_csv(path, sep=sep, header=0 if header else None)
-    df_map["{{s.id}}"] = df
-    last_df = df
+        path = args.input_csv or "{{ s.config.get("file_path", "") }}"
+        sep = "{{ s.config.get("separator", ",") }}"
+        header = "{{ s.config.get("header", "true") }}".lower() == "true"
+        df = pd.read_csv(path, sep=sep, header=0 if header else None)
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tFileInputExcel" %}
-    # Read an Excel sheet into a DataFrame
-    path = args.input_csv or "{{ s.config.get("file_path", "") }}"
-    sheet = "{{ s.config.get("sheet", 0) }}"
-    header = "{{ s.config.get("header", "true") }}".lower() == "true"
-    df = pd.read_excel(path, sheet_name=sheet, header=0 if header else None)
-    df_map["{{s.id}}"] = df
-    last_df = df
+        # Read an Excel sheet into a DataFrame
+        path = args.input_csv or "{{ s.config.get("file_path", "") }}"
+        sheet = "{{ s.config.get("sheet", 0) }}"
+        header = "{{ s.config.get("header", "true") }}".lower() == "true"
+        df = pd.read_excel(path, sheet_name=sheet, header=0 if header else None)
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tFilterRow" %}
-    # Apply a row level filter using pandas' query method.  The expression
-    # string should be valid Python/pandas syntax referencing column names.
-    expr_str = '{{ s.config.get("filter_expr", "True") }}'
-    df = last_df.query(expr_str)
-    df_map["{{s.id}}"] = df
-    last_df = df
+        # Apply a row level filter using pandas' query method.  The expression
+        # string should be valid Python/pandas syntax referencing column names.
+        expr_str = '{{ s.config.get("filter_expr", "True") }}'
+        df = last_df.query(expr_str)
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tMap" %}
-    # Select and/or compute new columns.  A JSON mapping is provided where
-    # keys are output column names and values are either '__keep__', '__copy__'
-    # (to preserve the existing column) or an expression to evaluate.
-    mapping = json.loads('{{ s.config.get("mapping", "{}") }}')
-    df = pd.DataFrame()
-    for new_col, expr_str in mapping.items():
-        if expr_str in ["__keep__", "__copy__"]:
-            df[new_col] = last_df[new_col]
-        else:
-            # Use pandas.eval to compute the expression in the context of the
-            # existing DataFrame.  This allows simple arithmetic and column
-            # references (e.g. 'age + 1').
-            df[new_col] = last_df.eval(expr_str)
-    df_map["{{s.id}}"] = df
-    last_df = df
+        # Select and/or compute new columns.  A JSON mapping is provided where
+        # keys are output column names and values are either '__keep__', '__copy__'
+        # (to preserve the existing column) or an expression to evaluate.
+        mapping = json.loads('{{ s.config.get("mapping", "{}") }}')
+        df = pd.DataFrame()
+        for new_col, expr_str in mapping.items():
+            if expr_str in ["__keep__", "__copy__"]:
+                df[new_col] = last_df[new_col]
+            else:
+                # Use pandas.eval to compute the expression in the context of the
+                # existing DataFrame.  This allows simple arithmetic and column
+                # references (e.g. 'age + 1').
+                df[new_col] = last_df.eval(expr_str)
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tJoin" %}
-    # Join two upstream DataFrames.  Inputs are ordered according to the
-    # connections defined in the Talend job.  join_type defaults to 'inner'.
-    left_df = df_map["{{ s.inputs[0] }}"]
-    right_df = df_map["{{ s.inputs[1] }}"]
-    left_on = "{{ s.config.get("left_on", "") }}"
-    right_on = "{{ s.config.get("right_on", "") }}"
-    join_type = "{{ s.config.get("join_type", "inner") }}"
-    df = left_df.merge(right_df, how=join_type, left_on=left_on, right_on=right_on)
-    df_map["{{s.id}}"] = df
-    last_df = df
+        # Join two upstream DataFrames.  Inputs are ordered according to the
+        # connections defined in the Talend job.  join_type defaults to 'inner'.
+        left_df = df_map["{{ s.inputs[0] }}"]
+        right_df = df_map["{{ s.inputs[1] }}"]
+        left_on = "{{ s.config.get("left_on", "") }}"
+        right_on = "{{ s.config.get("right_on", "") }}"
+        join_type = "{{ s.config.get("join_type", "inner") }}"
+        df = left_df.merge(right_df, how=join_type, left_on=left_on, right_on=right_on)
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tExtractDelimitedFields" %}
-    # Split a delimited column into multiple new columns
-    column = "{{ s.config.get("column", "") }}"
-    sep = "{{ s.config.get("separator", ",") }}"
-    new_cols = json.loads('{{ s.config.get("new_columns", "[]") }}')
-    parts = last_df[column].str.split(sep, expand=True)
-    for i, col_name in enumerate(new_cols):
-        last_df[col_name] = parts[i]
-    df_map["{{s.id}}"] = last_df
+        # Split a delimited column into multiple new columns
+        column = "{{ s.config.get("column", "") }}"
+        sep = "{{ s.config.get("separator", ",") }}"
+        new_cols = json.loads('{{ s.config.get("new_columns", "[]") }}')
+        parts = last_df[column].str.split(sep, expand=True)
+        for i, col_name in enumerate(new_cols):
+            last_df[col_name] = parts[i]
+        df_map["{{s.id}}"] = last_df
     {% elif s.type == "tAggregateRow" %}
-    # Aggregate rows based on group_by and aggregation mappings
-    group_by = json.loads('{{ s.config.get("group_by", "[]") }}')
-    aggregations = json.loads('{{ s.config.get("aggregations", "{}") }}')
-    df = last_df.groupby(group_by).agg(aggregations).reset_index()
-    df_map["{{s.id}}"] = df
-    last_df = df
+        # Aggregate rows based on group_by and aggregation mappings
+        group_by = json.loads('{{ s.config.get("group_by", "[]") }}')
+        aggregations = json.loads('{{ s.config.get("aggregations", "{}") }}')
+        df = last_df.groupby(group_by).agg(aggregations).reset_index()
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tLogRow" %}
-    # Print the first few rows of the current DataFrame.  to_string() is used
-    # to avoid truncation of wide columns.
-    print(last_df.head(10).to_string())
-    df_map["{{s.id}}"] = last_df
+        # Print the first few rows of the current DataFrame.  to_string() is used
+        # to avoid truncation of wide columns.
+        print(last_df.head(10).to_string())
+        df_map["{{s.id}}"] = last_df
     {% elif s.type == "tFileOutputDelimited" %}
-    # Write the DataFrame to a CSV file.  Coerce header and separator
-    # parameters to proper boolean and string values.
-    out_path = args.output_csv or "{{ s.config.get("file_path", "output.csv") }}"
-    sep = "{{ s.config.get("separator", ",") }}"
-    header = "{{ s.config.get("header", "true") }}".lower() == "true"
-    last_df.to_csv(out_path, index=False, sep=sep, header=header)
-    df_map["{{s.id}}"] = last_df
+        # Write the DataFrame to a CSV file.  Coerce header and separator
+        # parameters to proper boolean and string values.
+        out_path = args.output_csv or "{{ s.config.get("file_path", "output.csv") }}"
+        sep = "{{ s.config.get("separator", ",") }}"
+        header = "{{ s.config.get("header", "true") }}".lower() == "true"
+        last_df.to_csv(out_path, index=False, sep=sep, header=header)
+        df_map["{{s.id}}"] = last_df
     {% elif s.type == "tFileOutputExcel" %}
-    # Write the DataFrame to an Excel file
-    out_path = args.output_csv or "{{ s.config.get("file_path", "output.xlsx") }}"
-    sheet = "{{ s.config.get("sheet", "Sheet1") }}"
-    header = "{{ s.config.get("header", "true") }}".lower() == "true"
-    last_df.to_excel(out_path, index=False, sheet_name=sheet, header=header)
-    df_map["{{s.id}}"] = last_df
+        # Write the DataFrame to an Excel file
+        out_path = args.output_csv or "{{ s.config.get("file_path", "output.xlsx") }}"
+        sheet = "{{ s.config.get("sheet", "Sheet1") }}"
+        header = "{{ s.config.get("header", "true") }}".lower() == "true"
+        last_df.to_excel(out_path, index=False, sheet_name=sheet, header=header)
+        df_map["{{s.id}}"] = last_df
     {% else %}
-    # For components that don't perform any transformation (or are not yet
-    # supported) simply propagate the last DataFrame.
-    df_map["{{s.id}}"] = last_df
+        # For components that don't perform any transformation (or are not yet
+        # supported) simply propagate the last DataFrame.
+        df_map["{{s.id}}"] = last_df
     {% endif %}
+    except Exception as exc:
+        handle_component_error("{{s.name}}", exc)
     {% endfor %}
 
 

--- a/talend2python/templates/main_pyspark.py.j2
+++ b/talend2python/templates/main_pyspark.py.j2
@@ -3,6 +3,8 @@ import json
 import pandas as pd
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import expr, col, split
+from talend2python.runtime.utils import handle_component_error
+from talend2python.runtime.routines import registry
 
 
 def parse_args():
@@ -19,88 +21,92 @@ def main():
     spark = SparkSession.builder.appName("talend2python").getOrCreate()
     df_map = {}
     last_df = None
+    globals().update(registry)
     {% for s in steps %}
     # Node: {{s.name}} ({{s.type}})
+    try:
 {% if s.type == "tFileInputDelimited" %}
-    path = args.input_csv or "{{ s.config.get("file_path", "") }}"
-    header = "{{ s.config.get("header", "true") }}".lower() == "true"
-    sep = "{{ s.config.get("separator", ",") }}"
-    df = spark.read.option("header", header).option("inferSchema", True).option("sep", sep).csv(path)
-    df_map["{{s.id}}"] = df
-    last_df = df
+        path = args.input_csv or "{{ s.config.get("file_path", "") }}"
+        header = "{{ s.config.get("header", "true") }}".lower() == "true"
+        sep = "{{ s.config.get("separator", ",") }}"
+        df = spark.read.option("header", header).option("inferSchema", True).option("sep", sep).csv(path)
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tFileInputExcel" %}
-    # Load an Excel sheet using pandas then convert to Spark DataFrame
-    path = args.input_csv or "{{ s.config.get("file_path", "") }}"
-    sheet = "{{ s.config.get("sheet", 0) }}"
-    header = "{{ s.config.get("header", "true") }}".lower() == "true"
-    pdf = pd.read_excel(path, sheet_name=sheet, header=0 if header else None)
-    df = spark.createDataFrame(pdf)
-    df_map["{{s.id}}"] = df
-    last_df = df
+        # Load an Excel sheet using pandas then convert to Spark DataFrame
+        path = args.input_csv or "{{ s.config.get("file_path", "") }}"
+        sheet = "{{ s.config.get("sheet", 0) }}"
+        header = "{{ s.config.get("header", "true") }}".lower() == "true"
+        pdf = pd.read_excel(path, sheet_name=sheet, header=0 if header else None)
+        df = spark.createDataFrame(pdf)
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tFilterRow" %}
-    expr_str = '{{ s.config.get("filter_expr", "true") }}'
-    df = last_df.filter(expr(expr_str))
-    df_map["{{s.id}}"] = df
-    last_df = df
+        expr_str = '{{ s.config.get("filter_expr", "true") }}'
+        df = last_df.filter(expr(expr_str))
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tMap" %}
-    mapping = json.loads('{{ s.config.get("mapping", "{}") }}')
-    selects = []
-    for new_col, expr_str in mapping.items():
-        if expr_str in ["__keep__", "__copy__"]:
-            selects.append(col(new_col))
-        else:
-            # Use Spark SQL expr to evaluate the expression string.  This allows
-            # column arithmetic and function calls recognized by Spark.
-            selects.append(expr(expr_str).alias(new_col))
-    df = last_df.select(*selects)
-    df_map["{{s.id}}"] = df
-    last_df = df
+        mapping = json.loads('{{ s.config.get("mapping", "{}") }}')
+        selects = []
+        for new_col, expr_str in mapping.items():
+            if expr_str in ["__keep__", "__copy__"]:
+                selects.append(col(new_col))
+            else:
+                # Use Spark SQL expr to evaluate the expression string.  This allows
+                # column arithmetic and function calls recognized by Spark.
+                selects.append(expr(expr_str).alias(new_col))
+        df = last_df.select(*selects)
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tJoin" %}
-    # Join two upstream DataFrames using Spark's join API.  The join type
-    # defaults to inner if not specified.
-    left_df = df_map["{{ s.inputs[0] }}"]
-    right_df = df_map["{{ s.inputs[1] }}"]
-    left_on = "{{ s.config.get("left_on", "") }}"
-    right_on = "{{ s.config.get("right_on", "") }}"
-    join_type = "{{ s.config.get("join_type", "inner") }}"
-    df = left_df.join(right_df, left_df[left_on] == right_df[right_on], how=join_type)
-    df_map["{{s.id}}"] = df
-    last_df = df
+        # Join two upstream DataFrames using Spark's join API.  The join type
+        # defaults to inner if not specified.
+        left_df = df_map["{{ s.inputs[0] }}"]
+        right_df = df_map["{{ s.inputs[1] }}"]
+        left_on = "{{ s.config.get("left_on", "") }}"
+        right_on = "{{ s.config.get("right_on", "") }}"
+        join_type = "{{ s.config.get("join_type", "inner") }}"
+        df = left_df.join(right_df, left_df[left_on] == right_df[right_on], how=join_type)
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tExtractDelimitedFields" %}
-    # Split a delimited string column into multiple columns using Spark split
-    column = "{{ s.config.get("column", "") }}"
-    sep = "{{ s.config.get("separator", ",") }}"
-    new_cols = json.loads('{{ s.config.get("new_columns", "[]") }}')
-    split_col = split(last_df[column], sep)
-    for idx, name in enumerate(new_cols):
-        last_df = last_df.withColumn(name, split_col.getItem(idx))
-    df_map["{{s.id}}"] = last_df
+        # Split a delimited string column into multiple columns using Spark split
+        column = "{{ s.config.get("column", "") }}"
+        sep = "{{ s.config.get("separator", ",") }}"
+        new_cols = json.loads('{{ s.config.get("new_columns", "[]") }}')
+        split_col = split(last_df[column], sep)
+        for idx, name in enumerate(new_cols):
+            last_df = last_df.withColumn(name, split_col.getItem(idx))
+        df_map["{{s.id}}"] = last_df
     {% elif s.type == "tAggregateRow" %}
-    # Group and aggregate rows
-    group_by = json.loads('{{ s.config.get("group_by", "[]") }}')
-    aggregations = json.loads('{{ s.config.get("aggregations", "{}") }}')
-    df = last_df.groupBy(*[col(c) for c in group_by]).agg(aggregations)
-    df_map["{{s.id}}"] = df
-    last_df = df
+        # Group and aggregate rows
+        group_by = json.loads('{{ s.config.get("group_by", "[]") }}')
+        aggregations = json.loads('{{ s.config.get("aggregations", "{}") }}')
+        df = last_df.groupBy(*[col(c) for c in group_by]).agg(aggregations)
+        df_map["{{s.id}}"] = df
+        last_df = df
     {% elif s.type == "tLogRow" %}
-    last_df.show(10, truncate=False)
-    df_map["{{s.id}}"] = last_df
+        last_df.show(10, truncate=False)
+        df_map["{{s.id}}"] = last_df
     {% elif s.type == "tFileOutputDelimited" %}
-    out_path = args.output_csv or "{{ s.config.get("file_path", "output.csv") }}"
-    header = "{{ s.config.get("header", "true") }}".lower() == "true"
-    sep = "{{ s.config.get("separator", ",") }}"
-    last_df.coalesce(1).write.mode("overwrite").option("header", header).option("sep", sep).csv(out_path)
-    df_map["{{s.id}}"] = last_df
+        out_path = args.output_csv or "{{ s.config.get("file_path", "output.csv") }}"
+        header = "{{ s.config.get("header", "true") }}".lower() == "true"
+        sep = "{{ s.config.get("separator", ",") }}"
+        last_df.coalesce(1).write.mode("overwrite").option("header", header).option("sep", sep).csv(out_path)
+        df_map["{{s.id}}"] = last_df
     {% elif s.type == "tFileOutputExcel" %}
-    # Write to Excel via pandas
-    out_path = args.output_csv or "{{ s.config.get("file_path", "output.xlsx") }}"
-    sheet = "{{ s.config.get("sheet", "Sheet1") }}"
-    header = "{{ s.config.get("header", "true") }}".lower() == "true"
-    last_df.toPandas().to_excel(out_path, index=False, sheet_name=sheet, header=header)
-    df_map["{{s.id}}"] = last_df
+        # Write to Excel via pandas
+        out_path = args.output_csv or "{{ s.config.get("file_path", "output.xlsx") }}"
+        sheet = "{{ s.config.get("sheet", "Sheet1") }}"
+        header = "{{ s.config.get("header", "true") }}".lower() == "true"
+        last_df.toPandas().to_excel(out_path, index=False, sheet_name=sheet, header=header)
+        df_map["{{s.id}}"] = last_df
     {% else %}
-    df_map["{{s.id}}"] = last_df
+        df_map["{{s.id}}"] = last_df
     {% endif %}
+    except Exception as exc:
+        handle_component_error("{{s.name}}", exc)
     {% endfor %}
     spark.stop()
 

--- a/talend2python_framework/tests/test_parser_routines.py
+++ b/talend2python_framework/tests/test_parser_routines.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from talend2python.parsers.talend_xml_parser import parse_talend_item
+
+
+ROUTINE_ITEM = (
+    Path(__file__).resolve().parents[1]
+    / "examples/jobs/sample_talend_job/ProductSampleJob_0.1.item"
+)
+
+
+def test_parse_routines():
+    g = parse_talend_item(str(ROUTINE_ITEM))
+    assert "TalendDate" in g.routines
+    assert "StringHandling" in g.routines
+

--- a/talend2python_framework/tests/test_runtime_utils.py
+++ b/talend2python_framework/tests/test_runtime_utils.py
@@ -1,0 +1,13 @@
+import pytest
+
+from talend2python.runtime.utils import handle_component_error, Talend2PyError
+
+
+def test_handle_component_error_wraps_exception():
+    with pytest.raises(Talend2PyError) as excinfo:
+        try:
+            raise ValueError("bad")
+        except Exception as e:
+            handle_component_error("Comp", e)
+    assert "Comp" in str(excinfo.value)
+


### PR DESCRIPTION
## Summary
- capture routine declarations in Talend jobs
- add routine registry for user-defined functions
- introduce Talend2PyError and wrap generated steps with component-level error handling

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2b79ed5083339685a7a727b7b95e